### PR TITLE
Make breaker a noop when config is null

### DIFF
--- a/src/breaker.js
+++ b/src/breaker.js
@@ -79,7 +79,7 @@ function breaker(config, emitter) {
     closeCircuit,
     status,
 
-    // TODO DPL: Deprecate this contract and remove duplicated functions (also, `close` === `restore`?)
+    // TODO DPL: Deprecate this contract and remove duplicated functions (keep xyzCircuit?)
     open: openCircuit,
     close: restoreCircuit,
   };

--- a/src/breaker.js
+++ b/src/breaker.js
@@ -4,7 +4,7 @@
 
 /* Requires ------------------------------------------------------------------*/
 
-const { tween } = require('./utils.js');
+const {tween} = require('./utils.js');
 
 /* Methods -------------------------------------------------------------------*/
 
@@ -27,6 +27,7 @@ function breaker(config, emitter) {
 
   function closeCircuit() {
     if (!config.breaker) return;
+
     reset();
     active = false;
     step = 0;
@@ -35,6 +36,7 @@ function breaker(config, emitter) {
 
   function restoreCircuit() {
     if (!config.breaker) return;
+
     reset();
     active = false;
     emitter.emit('circuitRestored', status());
@@ -47,7 +49,9 @@ function breaker(config, emitter) {
   }
 
   function openCircuit() {
-    if (config.breaker && active === false) {
+    if (!config.breaker) return;
+
+    if (active === false) {
       violations++;
       if (config.breaker.tolerance <= violations) {
         reset();
@@ -58,18 +62,27 @@ function breaker(config, emitter) {
         active = true;
         emitter.emit('circuitBroken', status(ttl));
         timer = setTimeout(restoreCircuit, ttl);
-      }
-      else {
+      } else {
         setTimeout(decreaseViolation, config.breaker.toleranceFrame);
       }
     }
   }
 
   function status(ttl) {
-    return { step, active, ttl };
+    return {step, active, ttl};
   }
 
-  return { circuitError, openCircuit, restoreCircuit, closeCircuit, status };
+  return {
+    circuitError,
+    openCircuit,
+    restoreCircuit,
+    closeCircuit,
+    status,
+
+    // TODO DPL: Deprecate this contract and remove duplicated functions (also, `close` === `restore`?)
+    open: openCircuit,
+    close: restoreCircuit,
+  };
 }
 
 /* Exports -------------------------------------------------------------------*/

--- a/src/index.js
+++ b/src/index.js
@@ -33,14 +33,15 @@ class HaStore extends EventEmitter {
       this.setMaxListeners(Infinity);
     }
 
-    const circuitBreaker = breaker(this.config, this);
-    this.breaker = {
-      ...circuitBreaker,
-      open: circuitBreaker.openCircuit,
-      close: circuitBreaker.restoreCircuit
-    };
+    this.breaker = breaker(this.config.breaker, this);
 
-    this.queue = queue(this.config, this, store(this.config, this), this.config.store, circuitBreaker);
+    this.queue = queue(
+      this.config,
+      this,
+      store(this.config, this),
+      this.config.store,
+      this.breaker,
+    );
   }
 
   /**

--- a/src/options.js
+++ b/src/options.js
@@ -47,6 +47,21 @@ function hydrateStoreOptions(storeOptions = {}) {
 
 }
 
+function hydrateIfNotNull(baseConfig, defaultConfig) {
+  if (baseConfig === null) {
+    return null;
+  }
+
+  if (!baseConfig) {
+    return {...defaultConfig};
+  }
+
+  return {
+    ...defaultConfig,
+    ...baseConfig,
+  };
+}
+
 function hydrateConfig(config = {}) {
   return {
     ...config,
@@ -66,11 +81,7 @@ function hydrateConfig(config = {}) {
       ...defaultConfig.cache,
       ...config.cache || {},
     },
-    breaker: {
-      ...defaultConfig.breaker,
-      ...config.breaker || {},
-    },
-
+    breaker: hydrateIfNotNull(config.breaker, defaultConfig.breaker),
   };
 }
 

--- a/tests/unit/breaker.spec.js
+++ b/tests/unit/breaker.spec.js
@@ -5,7 +5,7 @@
 /* Requires ------------------------------------------------------------------*/
 
 const breaker = require('../../src/breaker.js');
-const { exp } = require('../../src/utils.js');
+const {exp} = require('../../src/utils.js');
 const EventEmitter = require('events').EventEmitter;
 const expect = require('chai').expect;
 const sinon = require('sinon');
@@ -27,18 +27,40 @@ const config = {
 describe('breaker', () => {
   let testCircuit;
   let testEmitter;
-  
+
+  const assertIsInavtive = (status) => expect(status).to.be.deep.equal({active: false, step: 0, ttl: undefined});
+
+  it('should be a noop if no configuration is supplied', () => {
+    const stubbedEmitter = new EventEmitter();
+    sinon.spy(stubbedEmitter, 'emit');
+
+    const testBreaker = breaker({breaker: null}, stubbedEmitter);
+    assertIsInavtive(testBreaker.status());
+
+    testBreaker.openCircuit();
+    assertIsInavtive(testBreaker.status());
+
+    testBreaker.restoreCircuit();
+    assertIsInavtive(testBreaker.status());
+
+    testBreaker.closeCircuit();
+    assertIsInavtive(testBreaker.status());
+
+    sinon.assert.notCalled(stubbedEmitter.emit);
+
+  });
+
   describe('#closeCircuit', () => {
     beforeEach(() => {
       testEmitter = new EventEmitter();
       testCircuit = breaker(config, testEmitter);
     });
-      
+
     it('should close an opened circuit', (done) => {
       testCircuit.openCircuit();
       testEmitter.on('circuitRecovered', (status) => {
         expect(testCircuit.status()).to.deep.equal(status);
-        expect(testCircuit.status()).to.deep.equal({ step: 0, active: false, ttl: undefined });
+        expect(testCircuit.status()).to.deep.equal({step: 0, active: false, ttl: undefined});
         done();
       });
       testCircuit.closeCircuit();
@@ -50,7 +72,7 @@ describe('breaker', () => {
       testEmitter = new EventEmitter();
       testCircuit = breaker(config, testEmitter);
     });
-          
+
     it('should open a circuit', (done) => {
       testEmitter.on('circuitBroken', (status) => {
         expect(status.step).to.equal(1);
@@ -58,7 +80,7 @@ describe('breaker', () => {
         expect(status.ttl).to.be.at.least(1);
         testEmitter.on('circuitRestored', (savedStatus) => {
           expect(testCircuit.status()).to.deep.equal(savedStatus);
-          expect(testCircuit.status()).to.deep.equal({ step: 1, active: false, ttl: undefined });
+          expect(testCircuit.status()).to.deep.equal({step: 1, active: false, ttl: undefined});
           done();
         });
       });
@@ -76,7 +98,7 @@ describe('breaker', () => {
         expect(status.ttl).to.be.at.least(1);
         testEmitter.on('circuitRestored', (savedStatus) => {
           expect(testCircuit.status()).to.deep.equal(savedStatus);
-          expect(testCircuit.status()).to.deep.equal({ step: 1, active: false, ttl: undefined });
+          expect(testCircuit.status()).to.deep.equal({step: 1, active: false, ttl: undefined});
           done();
         });
       });

--- a/tests/unit/breaker.spec.js
+++ b/tests/unit/breaker.spec.js
@@ -28,23 +28,23 @@ describe('breaker', () => {
   let testCircuit;
   let testEmitter;
 
-  const assertIsInavtive = (status) => expect(status).to.be.deep.equal({active: false, step: 0, ttl: undefined});
+  const assertIsInactive = (status) => expect(status).to.be.deep.equal({active: false, step: 0, ttl: undefined});
 
   it('should be a noop if no configuration is supplied', () => {
     const stubbedEmitter = new EventEmitter();
     sinon.spy(stubbedEmitter, 'emit');
 
     const testBreaker = breaker({breaker: null}, stubbedEmitter);
-    assertIsInavtive(testBreaker.status());
+    assertIsInactive(testBreaker.status());
 
     testBreaker.openCircuit();
-    assertIsInavtive(testBreaker.status());
+    assertIsInactive(testBreaker.status());
 
     testBreaker.restoreCircuit();
-    assertIsInavtive(testBreaker.status());
+    assertIsInactive(testBreaker.status());
 
     testBreaker.closeCircuit();
-    assertIsInavtive(testBreaker.status());
+    assertIsInactive(testBreaker.status());
 
     sinon.assert.notCalled(stubbedEmitter.emit);
 

--- a/tests/unit/index.spec.js
+++ b/tests/unit/index.spec.js
@@ -3,17 +3,13 @@
  */
 
 /* Requires ------------------------------------------------------------------*/
-
-const queue = require('../../src/queue.js');
 const {exp, contextKey} = require('../../src/utils.js');
+const {noop} = require('./utils');
 const root = require('../../src/index.js');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 
-/* Tests ---------------------------------------------------------------------*/
-const noop = () => {
-};
-
+/* Utils ---------------------------------------------------------------------*/
 function checkForPublicProperties(store) {
   expect(store.get).to.not.be.undefined;
   expect(store.set).to.not.be.undefined;
@@ -23,39 +19,13 @@ function checkForPublicProperties(store) {
   expect(store.breaker).to.not.be.undefined;
 }
 
+/* Tests ---------------------------------------------------------------------*/
+
 describe('index', () => {
   describe('#constructor', () => {
     it('should produce a batcher with all the expected properties when called with minimal arguments', () => {
       const test = root({resolver: noop});
       checkForPublicProperties(test);
-    });
-
-    it('should hydrate the configuration with default values if none are provided', () => {
-      // TODO: Move to its own spec file (tests/unit/options.spec.js)
-      const defaultConfig = {
-        "storeOptions": {
-          "pluginRecoveryDelay": 10000,
-          "pluginFallback": true,
-          "memoryLimit": 0.9,
-          "recordLimit": Infinity,
-        },
-        "timeout": null,
-        "batch": {"tick": 50, "max": 100},
-        "retry": {curve: exp, "base": 5, "steps": 3, "limit": 5000},
-        "cache": {curve: exp, "base": 1000, "steps": 5, "limit": 30000},
-        "breaker": {
-          curve: exp,
-          "base": 1000,
-          "steps": 10,
-          "limit": 65535,
-          "tolerance": 1,
-          "toleranceFrame": 10000
-        },
-        resolver: noop,
-      };
-      const test = root({resolver: noop});
-
-      expect(defaultConfig).to.deep.equal(test.config, "Did you change the default configuration?");
     });
 
     it('should produce a batcher with all the expected properties when called with false arguments', () => {
@@ -79,12 +49,6 @@ describe('index', () => {
         retry: true,
       });
       checkForPublicProperties(test);
-      expect(test.config).to.deep.contain({
-        cache: {limit: 30000, steps: 5, base: 1000, curve: exp},
-        batch: {max: 100, tick: 50},
-        retry: {limit: 5000, steps: 3, base: 5, curve: exp},
-        breaker: {limit: 65535, steps: 10, base: 1000, curve: exp, tolerance: 1, toleranceFrame: 10000},
-      });
     });
 
     it('should produce a batcher with all the merged config when called with custom requirements', () => {
@@ -97,12 +61,6 @@ describe('index', () => {
         breaker: {steps: 1},
       });
       checkForPublicProperties(test);
-      expect(test.config).to.deep.contain({
-        cache: {limit: 30000, steps: 5, base: 2, curve: exp},
-        batch: {max: 12, tick: 50},
-        retry: {limit: 35, steps: 3, base: 5, curve: exp},
-        breaker: {limit: 65535, steps: 1, base: 1000, curve: exp, tolerance: 1, toleranceFrame: 10000},
-      });
     });
 
     it('should throw if called with missing required arguments', () => {

--- a/tests/unit/options.spec.js
+++ b/tests/unit/options.spec.js
@@ -1,0 +1,101 @@
+/**
+ * Utils unit tests
+ */
+
+/* Requires ------------------------------------------------------------------*/
+const {hydrateConfig} = require('../../src/options');
+const batcher = require('../../src/index');
+const {exp} = require('../../src/utils');
+const {noop} = require('./utils');
+const expect = require('chai').expect;
+
+/* Tests ---------------------------------------------------------------------*/
+
+describe('options', () => {
+
+  describe('#basicParser', () => {
+    it('should produce a batcher with all the default config when called with true requirements', () => {
+      const test = batcher({
+        resolver: noop,
+        uniqueParams: ['a', 'b', 'c'],
+        cache: true,
+        batch: true,
+        retry: true,
+      });
+
+      expect(test.config).to.deep.contain({
+        cache: {limit: 30000, steps: 5, base: 1000, curve: exp},
+        batch: {max: 100, tick: 50},
+        retry: {limit: 5000, steps: 3, base: 5, curve: exp},
+        breaker: {limit: 65535, steps: 10, base: 1000, curve: exp, tolerance: 1, toleranceFrame: 10000},
+      });
+    });
+
+    it('should produce a batcher with all the merged config when called with custom requirements', () => {
+      const test = batcher({
+        resolver: noop,
+        uniqueParams: ['a', 'b', 'c'],
+        cache: {base: 2},
+        batch: {max: 12},
+        retry: {limit: 35},
+        breaker: {steps: 1},
+      });
+
+      expect(test.config).to.deep.contain({
+        cache: {limit: 30000, steps: 5, base: 2, curve: exp},
+        batch: {max: 12, tick: 50},
+        retry: {limit: 35, steps: 3, base: 5, curve: exp},
+        breaker: {limit: 65535, steps: 1, base: 1000, curve: exp, tolerance: 1, toleranceFrame: 10000},
+      });
+    });
+
+    it('should hydrate the configuration with default values if none are provided', () => {
+      const defaultConfig = {
+        "storeOptions": {
+          "pluginRecoveryDelay": 10000,
+          "pluginFallback": true,
+          "memoryLimit": 0.9,
+          "recordLimit": Infinity,
+        },
+        "timeout": null,
+        "batch": {"tick": 50, "max": 100},
+        "retry": {curve: exp, "base": 5, "steps": 3, "limit": 5000},
+        "cache": {curve: exp, "base": 1000, "steps": 5, "limit": 30000},
+        "breaker": {
+          curve: exp,
+          "base": 1000,
+          "steps": 10,
+          "limit": 65535,
+          "tolerance": 1,
+          "toleranceFrame": 10000
+        },
+      };
+      const finalConfig = hydrateConfig({});
+
+      expect(defaultConfig).to.deep.equal(finalConfig, "Did you change the default configuration?");
+    });
+
+    it('should not hydrate a module\'s configuration if its base config is `null`', () => {
+      const baseConfig = {
+        "storeOptions": {
+          "pluginRecoveryDelay": 10000,
+          "pluginFallback": true,
+          "memoryLimit": 0.9,
+          "recordLimit": Infinity,
+        },
+        "timeout": null,
+        "batch": null,
+        "retry": null,
+        "cache": null,
+        "breaker": null,
+      };
+
+      const finalConfig = hydrateConfig(baseConfig);
+      expect(finalConfig.batch).to.not.be.null;
+      expect(finalConfig.retry).to.not.be.null;
+      expect(finalConfig.cache).to.not.be.null;
+      expect(finalConfig.breaker).to.be.null;
+    });
+  });
+
+});

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -1,0 +1,7 @@
+const noop = () => {
+};
+
+
+module.exports = {
+  noop,
+};


### PR DESCRIPTION
- Prevent `options.js` from creating a default config for `config.breaker` if the supplied configuration is `null`.
- `breaker.js` should be a noop if no breaker configuration is present.