### PR TITLE
V2.1.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class HaStore extends EventEmitter {
         const errors = results.filter(r => r.status === 0);
         const entities = results.filter(r => r.status === 1);
         if (entities.length === 0) throw { errors: errors.map(e => e.reason) };
-        return (Array.isArray(ids)) ? results.map(r => r.value) : results[0].value;
+        return (Array.isArray(ids)) ? entities.map(r => r.value) : entities[0].value;
       });
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,6 +62,16 @@ function deferred() {
   return { promise, resolve, reject };
 }
 
+function reflect(promise) {
+  if (promise instanceof Promise) {
+    return promise.then(
+      value => ({ status: 1, value }),
+      error => ({ status: 0, reason: error }),
+    );
+  }
+  return Promise.resolve({ status: 1, value: promise });
+}
+
 function contextKey(u, params = {}) {
   return Array.from(u || []).map(opt => `${opt}=${JSON.stringify(params[opt])}`).join(';');
 }
@@ -74,4 +84,4 @@ const contextRecordKey = key => id => recordKey(key, id);
 
 /* Exports -------------------------------------------------------------------*/
 
-module.exports = { deferred, basicParser, contextKey, recordKey, contextRecordKey };
+module.exports = { deferred, basicParser, contextKey, recordKey, contextRecordKey, reflect };

--- a/tests/profiling/worker.js
+++ b/tests/profiling/worker.js
@@ -39,7 +39,7 @@ function handleRequest(id, language) {
     .then((result) => {
         finished = true;
         if (!result || result.id !== id || result.language !== language) {
-            throw new Error(`Integrity test failed: ${result} does not match {${id} ${language}}`);
+            throw new Error(`Integrity test failed: ${JSON.stringify(result)} does not match {${id} ${language}}`);
         }
         suite.sum += (Date.now() - before);
         suite.completed++;


### PR DESCRIPTION
## Major changes
- `get` now tries to settle all promises
  - Partially successful requests now return the list of valid results
  - If all of them failed, it will throw an error with the individual failures
  - Interface remains otherwise unchanged