### PR TITLE
V2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ HA-store emits events to track cache hits, miss and outbound requests.
 Event | Description
 --- | ---
 cacheHit | When the requested item is present in the microcache, or is already being fetched. Prevents another request from being created.
+cacheMiss | When the requested item not cached or coalesced and must be fetched.
 coalescedHit | When a record query successfully hooks to the promise of the same record in transit.
 query | When a batch of requests is about to be sent.
 queryFailed | Indicates that the batch has failed. Retry policy will dictate if it should be re-attempted.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-store",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Efficient data fetching",
   "main": "src/index.js",
   "scripts": {

--- a/src/queries.js
+++ b/src/queries.js
@@ -44,7 +44,7 @@ function queriesStore(config, emitter, targetStore) {
         const sizeLimit = config.batch && config.batch.max || 1;
         const query = queries[key].find(q => q.size < sizeLimit && q.state === 0) || createQuery(key, params);
         query.size++;
-        if (!(id in query.handles)) query.handles[id] = deferred();
+        if (!(id in query.handles)) query.handles[`${id}`] = deferred();
         if (query.contexts.indexOf(context) == -1) query.contexts.push(context);
 
         if (query.size >= sizeLimit) runQuery(query);

--- a/src/queries.js
+++ b/src/queries.js
@@ -8,6 +8,7 @@ function queriesStore(config, emitter, targetStore) {
 
         let numCoalesced = 0;
         let numCached = 0;
+        let numMisses = 0;
 
         const handles = [];
         for (let i = 0; i < ids.length; i++) {
@@ -31,10 +32,14 @@ function queriesStore(config, emitter, targetStore) {
         }
 
         for (let i = 0; i < ids.length; i++) {
-            if (handles[i] === undefined) handles[i] = assignQuery(key, ids[i], params, context);
+            if (handles[i] === undefined) {
+                numMisses++;
+                handles[i] = assignQuery(key, ids[i], params, context);
+            }
         }
 
         if (numCached > 0) emitter.emit('cacheHit', { key, found: numCached });
+        if (numMisses > 0) emitter.emit('cacheMiss', { key, found: numCached });
         if (numCoalesced > 0)  emitter.emit('coalescedHit', { key, found: numCoalesced });
 
         return handles;

--- a/src/queries.js
+++ b/src/queries.js
@@ -39,7 +39,7 @@ function queriesStore(config, emitter, targetStore) {
         }
 
         if (numCached > 0) emitter.emit('cacheHit', { key, found: numCached });
-        if (numMisses > 0) emitter.emit('cacheMiss', { key, found: numCached });
+        if (numMisses > 0) emitter.emit('cacheMiss', { key, found: numMisses });
         if (numCoalesced > 0)  emitter.emit('coalescedHit', { key, found: numCoalesced });
 
         return handles;

--- a/src/queries.js
+++ b/src/queries.js
@@ -13,10 +13,10 @@ function queriesStore(config, emitter, targetStore) {
         for (let i = 0; i < ids.length; i++) {
             handles[i] = undefined;
 
-            const existingQuery = queries[key].find(query => query.handles[ids[i]]);
-            if (existingQuery && existingQuery.handles[ids[i]].promise) {
+            const existingQuery = queries[key].find(query => query.handles.has(ids[i]));
+            if (existingQuery) {
                 numCoalesced++;
-                handles[i] = existingQuery.handles[ids[i]].promise;
+                handles[i] = existingQuery.handles.get(ids[i]).promise;
             }
         }
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -44,15 +44,15 @@ function queriesStore(config, emitter, targetStore) {
         const sizeLimit = config.batch && config.batch.max || 1;
         const query = queries[key].find(q => q.size < sizeLimit && q.state === 0) || createQuery(key, params);
         query.size++;
-        if (!(id in query.handles)) query.handles[`${id}`] = deferred();
+        if (!query.handles.has(id)) query.handles.set(id, deferred());
         if (query.contexts.indexOf(context) == -1) query.contexts.push(context);
 
         if (query.size >= sizeLimit) runQuery(query);
-        return query.handles[id].promise;
+        return query.handles.get(id).promise;
     }
 
     function createQuery(key, params) {
-        const query = { uid: Math.random().toString(36), key, params, handles: {}, state: 0, timer: null, contexts: [], size: 0 };
+        const query = { uid: Math.random().toString(36), key, params, handles: new Map(), state: 0, timer: null, contexts: [], size: 0 };
         queries[key].push(query);
 
         query.timer = setTimeout(() => runQuery(query), config.batch && config.batch.tick || 0);
@@ -69,25 +69,23 @@ function queriesStore(config, emitter, targetStore) {
         query.state = 1;
         clearTimeout(query.timer);
         emitter.emit('query', query);
-        config.resolver(Object.keys(query.handles), query.params, query.contexts)
+        config.resolver(Array.from(query.handles.keys()), query.params, query.contexts)
             .then(handleQuerySuccess.bind(null, query), handleQueryError.bind(null, query));
     }
 
     function handleQueryError(query, error) {
         query.state = 2;
         emitter.emit('queryFailed', { key: query.key, uid: query.uid, size: query.size, params: query.params, error });
-        for (const handle in query.handles) {
-            query.handles[handle].reject(error);
-        }
+        Array.from(query.handles.values()).forEach(handle => handle.reject(error));
         deleteQuery(query.key, query.uid);
     }
 
     function handleQuerySuccess(query, rawResponse) {
         query.state = 2;
         emitter.emit('querySuccess', { key: query.key, uid: query.uid, size: query.size, params: query.params });
-        const ids = Object.keys(query.handles);
+        const ids = Array.from(query.handles.keys());
         const entries = basicParser(rawResponse, ids, query.params);
-        ids.forEach(id => query.handles[id].resolve(entries[id]));
+        ids.forEach(id => query.handles.get(id).resolve(entries[id]));
         if (config.cache !== null) targetStore.set(contextRecordKey(query.key), ids, entries);
         deleteQuery(query.key, query.uid);
     }

--- a/tests/integration/batch.js
+++ b/tests/integration/batch.js
@@ -100,6 +100,19 @@ describe('Batching', () => {
         });
     });
 
+    // Objects sort numeric keys by default, which ruins user-specified ordering
+    it('should maintain id ordering with numeric ids', () => {
+      return Promise.all([
+        testStore.get(2, { language: 'fr' }),
+        testStore.get(1, { language: 'fr' })
+      ])
+        .then((result) => {
+          expect(result).to.deep.equal([{ id: '2', language: 'fr' }, { id: '1', language: 'fr' }]);
+          mockSource.expects('getAssets')
+            .once().withArgs(['2', '1'], { language: 'fr' });
+        });
+    });
+
     it('should properly bucket large requests', () => {
       testStore.config.batch = { max: 2, tick: 1 };
       return testStore.get(['foo', 'bar', 'abc', 'def', 'ghi'], { language: 'en' })

--- a/tests/integration/batch.js
+++ b/tests/integration/batch.js
@@ -100,14 +100,13 @@ describe('Batching', () => {
         });
     });
 
-    // Objects sort numeric keys by default, which ruins user-specified ordering
     it('should maintain id ordering with numeric ids', () => {
       return Promise.all([
         testStore.get(2, { language: 'fr' }),
         testStore.get(1, { language: 'fr' })
       ])
         .then((result) => {
-          expect(result).to.deep.equal([{ id: '2', language: 'fr' }, { id: '1', language: 'fr' }]);
+          expect(result).to.deep.equal([{ id: 2, language: 'fr' }, { id: 1, language: 'fr' }]);
           mockSource.expects('getAssets')
             .once().withArgs(['2', '1'], { language: 'fr' });
         });


### PR DESCRIPTION
## Summary

Bug fix for numeric ids ordering to be preserved.
Re-introduce `cacheMiss` events

## Changelist

- query handles is now a Map instead of an object, to preseve ordering and data type of ids
- Cache mis events are sent again

## Merge Checklist

 - [x] Verified locally
 - [x] Integration tests added
 - [x] Unit tests pass locally
 - [x] Integration tests pass locally
