### PR TITLE
bugfix: Added missing array types on HAStore.get ids

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,7 +36,7 @@ export interface HAStoreConfig {
 }
 
 export interface HAStore extends EventEmitter {
-  get(ids: string | number, params?: Params, context?: Serializable): Promise<Serializable>
+  get(ids: string | number | Array<string | number>, params?: Params, context?: Serializable): Promise<Serializable>
   set(items: Serializable, ids: string[] | number[], params?: Params): Promise<Serializable>
   clear(ids: RequestIds, params?: Params): void
   size(): { contexts: number, queries: number, records: number }


### PR DESCRIPTION
## Summary

Added missing array types for HAStore.get `ids` argument

## Changelist

index.d.ts HAStore.get

## Breaking changes

None

## Merge Checklist

 - [X] Verified locally
 - [ ] Unit Tests added
 - [ ] Integration tests added
 - [ ] Unit tests pass locally
 - [ ] Integration tests pass locally
